### PR TITLE
Line2d and GreyscaleConnectedComponentLabeler bug fixes

### DIFF
--- a/core/core-math/src/main/java/org/openimaj/math/geometry/line/Line2d.java
+++ b/core/core-math/src/main/java/org/openimaj/math/geometry/line/Line2d.java
@@ -517,20 +517,39 @@ public class Line2d implements Path2d, Cloneable {
 	 * @return TRUE if the point lies on this line.
 	 */
 	public boolean isOnLine(Point2d p, float tolerance)
-	{
-		// vertical line
-		if (begin.getX() == end.getX() && begin.getX() == p.getX())
-			return true;
-		// Horizontal line
-		if (begin.getY() == end.getY() && begin.getY() == p.getY())
-			return true;
-
-		final float a = (end.getY() - begin.getY()) / (end.getX() - begin.getX());
-		final float b = begin.getY() - a * begin.getX();
-		if (Math.abs(p.getY() - (a * p.getX() + b)) < tolerance)
-			return true;
-
+	{		
+		if (distanceToLine(p) < tolerance) return true;
+		
 		return false;
+	}
+	
+	/**
+	 * Returns the shortest distance between the point and this line. Note that this  
+	 * assumes the line travels to infinity in both directions.
+	 * @param p The point to test.
+	 * @return The distance from the point to the closest point on the line
+	 */
+	public float distanceToLine(Point2d p) {
+		// vertical line
+		if (begin.getX() == end.getX()) {
+				return Math.abs(begin.getX() - p.getX());
+		}
+
+		// Horizontal line
+		if (begin.getY() == end.getY()) {
+			return Math.abs(begin.getY() - p.getY());			
+		}
+
+		// Given the equation for a line as ax + by + c = 0 
+		float a = begin.getY() - end.getY();
+		float b = begin.getX() - end.getX();
+		float c = begin.getX() * end.getY() - end.getX() * begin.getY();
+		
+		//calculate the distance from the line to the point
+		// http://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line		
+		float distance = (float) (Math.abs(a * p.getX() + b * p.getY() + c) / Math.sqrt(a * a + b * b));
+
+		return distance;
 	}
 
 	/**

--- a/core/core-math/src/main/java/org/openimaj/math/geometry/line/Line2d.java
+++ b/core/core-math/src/main/java/org/openimaj/math/geometry/line/Line2d.java
@@ -541,13 +541,13 @@ public class Line2d implements Path2d, Cloneable {
 		}
 
 		// Given the equation for a line as ax + by + c = 0 
-		float a = begin.getY() - end.getY();
-		float b = begin.getX() - end.getX();
-		float c = begin.getX() * end.getY() - end.getX() * begin.getY();
+		float a = end.getY() - begin.getY();
+		float b = end.getX() - begin.getX();
+		float c = end.getX() * begin.getY() - begin.getX() * end.getY();
 		
 		//calculate the distance from the line to the point
 		// http://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line		
-		float distance = (float) (Math.abs(a * p.getX() + b * p.getY() + c) / Math.sqrt(a * a + b * b));
+		float distance = (float) (Math.abs(a * p.getX() - b * p.getY() + c) / Math.sqrt(a * a + b * b));
 
 		return distance;
 	}


### PR DESCRIPTION
Added distanceToLine method on line2d that calculates the shortest distance from the point to the line and use that function to fix a bug on isOnLine where distance was calculated incorrectly for lines that are nearly vertical.

Fixed flood fill bug on GreyscaleConnectedComponentLabeler: Images with horizontal lines of the target color would add the same pixel multiple times. Getting exponentially slower the longer the horizontal lines were.

Note that the floodFill method is in a few other places in the code and may need fixing there as well.