### PR TITLE
Bing API Dataset fixes

### DIFF
--- a/core/core/src/main/java/org/openimaj/util/api/auth/DefaultTokenFactory.java
+++ b/core/core/src/main/java/org/openimaj/util/api/auth/DefaultTokenFactory.java
@@ -459,4 +459,33 @@ public class DefaultTokenFactory implements TokenFactory {
 	public static <T> T get(Class<T> tokenClass, String name) {
 		return getInstance().getToken(tokenClass);
 	}
+	
+	/**
+	 * Convenience method equivalent to
+	 * {@code getInstance().deleteToken(tokenClass) }
+	 * 
+	 * @see #deleteToken(Class)
+	 * @param tokenClass the class of the token to delete
+	 * @throws BackingStoreException
+	 *             if a problem occurred communicating with the backing
+	 *             preference store
+	 */
+	public static <T> void delete(Class<T> tokenClass) throws BackingStoreException {
+		getInstance().deleteToken(tokenClass);
+	}
+	
+	/**
+	 * Convenience method equivalent to
+	 * {@code getInstance().deleteToken(tokenClass, name) }
+	 * 
+	 * @see #deleteToken(Class, String)
+	 * @param tokenClass the class of the token to delete
+	 * @param name the name of the token, or {@code null} for the default token
+	 * @throws BackingStoreException
+	 *             if a problem occurred communicating with the backing
+	 *             preference store
+	 */
+	public static <T> void delete(Class<T> tokenClass, String name) throws BackingStoreException {
+		getInstance().deleteToken(tokenClass, name);
+	}
 }


### PR DESCRIPTION
### Commit 3f5bb80
In the [`BingImageDataset` class](https://github.com/openimaj/openimaj/blob/master/core/core-image/src/main/java/org/openimaj/image/dataset/BingImageDataset.java), trying to get an image (such as when calling `BingImageDataset#get(int)`) from a Bing URL that was not actually an image file resulted in a `RunTimeException` being thrown. 

This isn't desirable, as this happens surprisingly often and causes the program to crash each time. An example URL of this is the 3rd result when one searches for `"dog"`:[`http://feelgrafix.com/data_images/out/6/790171-dog-pictures.jpg`](http://feelgrafix.com/data_images/out/6/790171-dog-pictures.jpg), which redirects to [`http://feelgrafix.com/790171-dog-pictures.html`](http://feelgrafix.com/790171-dog-pictures.html). 
Similarly, results for `"cat"` also have this problem. Therefore, the class has been changed, so that it returns `null` if this happens.

Additionally, if the API Key was incorrect, the method returned `null`, but printed out no information regard this. Now, when a HTTP 401 Unauthorised Error is received, this is printed.

### Commit 3beed52
Adds convenience methods [`DefaultFactoryToken#delete(Class<T>)` and `DefaultFactoryToken#delete(Class<T>, String)`](https://github.com/aloisklink/openimaj/blob/3beed524527640b7ee3c6dd1dcb7b0b266d451b4/core/core/src/main/java/org/openimaj/util/api/auth/DefaultTokenFactory.java). Previously, there were only `get()` functions, which created an API Key by using console input, and then cached it for future runs. However,
if the API Key was incorrectly entered, or the previous one became invalid, it was difficult to find a way to delete the cached version. By adding these convenience methods, it should be easy to see these methods in an IDE's autocomplete feature.