### PR TITLE
Updates .gitignore to Ignore More Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,87 @@
-.settings
-.project
-.classpath
-target/
+# ----- Site Generation Related Ignores --
+
+# scmpublisher
 site/src/site/resources/bibliography.bib
 site/src/site/resources/bibliography.txt
 site/src/site/static-html/bibliography.html
+
+# -----  Ignores .log files --------------
+# tools/picslurper/picslurper.log is generated when `mvn install` is run
+*.log
+
+# -----  Maven Related Ignores -----------
+target/
+
+# after running `mvn eclipse:eclipse`
+# core/core/maven-eclipse.xml file appeared
+maven-eclipse.xml
+
+# -----  Eclipse Related Ignores ---------
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# -------------- Java Related Ignores -------------------
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+# All compiled .jar files should go in maven target/ folder
+# *.jar #some jar files come for testing/dependencies
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Ignore JavaDocs
+doc/


### PR DESCRIPTION
The following files were created and not automatically ignored when the
commands `mvn install` and `mvn eclipse:eclipse` were run:

- `core/core/.externalToolBuilders/`
- `core/core/maven-eclipse.xml`
- `tools/picslurper/picslurper.log`

The default [`Java.gitignore`](https://github.com/github/gitignore/blob/master/Java.gitignore) file and [`Eclipse.gitignore`](https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore) ignores
were added.

Also, `*.log` files were ignored, as well as `maven-eclipse.xml` files.

`.jar` files, although part of the `Java.gitignore`, could not be ignored, as [there are some `.jar` files](https://github.com/openimaj/openimaj/search?utf8=%E2%9C%93&q=extension%3A.jar&type=Code) for testing and dependencies.

Now when running `git status`, these the files created by running `mvn install` and `mvn eclipse:eclipse` do not show up. 

The `.gitignore` file can be tested to see whether it ignores any existing repository files by running:
```bash
git rm -r --cached .
git add .
```