### PR TITLE
Fix LocalContrastFilter

### DIFF
--- a/image/image-processing/src/main/java/org/openimaj/image/processing/algorithm/LocalContrastFilter.java
+++ b/image/image-processing/src/main/java/org/openimaj/image/processing/algorithm/LocalContrastFilter.java
@@ -61,18 +61,20 @@ public class LocalContrastFilter implements SinglebandImageProcessor<Float, FIma
 	@Override
 	public void processImage(FImage image) {
 		final FImage tmpImage = new FImage(image.width, image.height);
-		float min = Float.MAX_VALUE;
-		float max = -Float.MAX_VALUE;
+		float min;
+		float max;
 
 		for (int y = 0; y < image.height; y++) {
 			for (int x = 0; x < image.width; x++) {
+				min = Float.MAX_VALUE;
+				max = -Float.MAX_VALUE;
 				for (final Pixel sp : support) {
 					final int xx = x + sp.x;
 					final int yy = y + sp.y;
 
 					if (xx >= 0 && xx < image.width - 1 && yy >= 0 && yy < image.height - 1) {
 						min = Math.min(min, image.pixels[yy][xx]);
-						max = Math.min(min, image.pixels[yy][xx]);
+						max = Math.max(max, image.pixels[yy][xx]);
 					}
 				}
 


### PR DESCRIPTION
Correctly computes the maximum value instead of computing the
minimum value a second time ("copy and paste" bug).

See: [Issues 133](https://github.com/openimaj/openimaj/issues/131)