### PR TITLE
 fixed a bug in DepthOfFieldEstimator.java

### DIFF
--- a/image/image-feature-extraction/src/main/java/org/openimaj/image/saliency/DepthOfFieldEstimator.java
+++ b/image/image-feature-extraction/src/main/java/org/openimaj/image/saliency/DepthOfFieldEstimator.java
@@ -132,8 +132,8 @@ public class DepthOfFieldEstimator implements SaliencyMapGenerator<FImage> {
 			FImage dx = blurred.process(DX_FILTER);
 			FImage dy = blurred.process(DY_FILTER);
 			
-			makeLogHistogram(xHistograms[i], dx);
-			makeLogHistogram(yHistograms[i], dy);
+			makeLogHistogram(xHistograms[i/kernelSizeStep], dx);
+			makeLogHistogram(yHistograms[i/kernelSizeStep], dy);
 		}
 		
 		FImage dx = image.process(DX_FILTER);


### PR DESCRIPTION
if maxKernelSize is 50 and kernelSizeStep is 25, an ArrayIndexOutOfBoundException was thrown in the first loop in analyseImage method because it was trying to access xHistograms[25] in second iteration.