### PR TITLE
Corrected inconsistency in threshold argument for RobustAffineTransformEstimator in Tutorial 5 causing invalid bounding box

### DIFF
--- a/documentation/tutorial/tutorial-content/src/main/resources/fundamentals/image/sift-matching.xml
+++ b/documentation/tutorial/tutorial-content/src/main/resources/fundamentals/image/sift-matching.xml
@@ -107,7 +107,7 @@ DisplayUtilities.display(basicMatches);</programlisting>
   <para>
     We’ll now set up a RANSAC model fitter configured to find Affine Transforms (using the <code>RobustAffineTransformEstimator</code> helper class) and our consistent matcher:
   </para>
-  <programlisting>RobustAffineTransformEstimator modelFitter = new RobustAffineTransformEstimator(5.0, 1500,
+  <programlisting>RobustAffineTransformEstimator modelFitter = new RobustAffineTransformEstimator(50.0, 1500,
   new RANSAC.PercentageInliersStoppingCondition(0.5));
 matcher = new ConsistentLocalFeatureMatcher2d&lt;Keypoint&gt;(
   new FastBasicKeypointMatcher&lt;Keypoint&gt;(8), modelFitter);


### PR DESCRIPTION
While completing Tutorial 5 I found the bounding box around the magazine was not being drawn properly.

![image](https://user-images.githubusercontent.com/7999692/67143322-4a5f7f00-f262-11e9-9895-a65e9528de74.png)

This was caused by a typo in the threshold argument for RobustAffineTransformEstimator in the tutorial, which was 5.0 instead of 50.0, as Jonathon Hare was using.

Do I need to update this value anywhere else? Or is this .xml file used as the source of truth for all tutorial formats (eg: PDF) too?