### PR TITLE
Issue 312 - upgrade Sanselan to commons-image to avoid CVEs

### DIFF
--- a/core/core-image/pom.xml
+++ b/core/core-image/pom.xml
@@ -63,11 +63,11 @@
       <version>1.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
-		<dependency>
-		   <groupId>org.apache.sanselan</groupId>
-		   <artifactId>sanselan</artifactId>
-		   <version>0.97-incubator</version>
-		</dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-imaging</artifactId>
+      <version>1.0-alpha2</version>
+    </dependency>
     <dependency>
       <groupId>com.caffeineowl</groupId>
       <artifactId>bezier-utils</artifactId>

--- a/core/core-image/src/main/java/org/openimaj/image/ExtendedImageIO.java
+++ b/core/core-image/src/main/java/org/openimaj/image/ExtendedImageIO.java
@@ -46,10 +46,7 @@ import javax.imageio.spi.IIORegistry;
 import javax.imageio.stream.ImageInputStream;
 import javax.media.jai.JAI;
 
-import org.apache.sanselan.ImageFormat;
-import org.apache.sanselan.ImageInfo;
-import org.apache.sanselan.ImageReadException;
-import org.apache.sanselan.Sanselan;
+import org.apache.commons.imaging.*;
 
 import com.sun.media.jai.codec.SeekableStream;
 
@@ -184,7 +181,7 @@ class ExtendedImageIO {
 		if (bi == null) {
 			buffer.reset();
 			try {
-				bi = Sanselan.getBufferedImage(buffer);
+				bi = Imaging.getBufferedImage(buffer);
 			} catch (final Throwable e) {
 				throw new IOException(e);
 			}
@@ -245,7 +242,7 @@ class ExtendedImageIO {
 	 * <code>ImageReader</code> claims to be able to read the stream,
 	 * <code>null</code> is returned.
 	 *
-	 * @param input
+	 * @param binput
 	 *            an <code>ImageInputStream</code> to read from.
 	 *
 	 * @return a <code>BufferedImage</code> containing the decoded contents of
@@ -264,15 +261,15 @@ class ExtendedImageIO {
 
 		ImageInfo info;
 		try {
-			info = Sanselan.getImageInfo(binput, null);
+			info = Imaging.getImageInfo(binput, null);
 		} catch (final ImageReadException ire) {
 			info = null;
 		} finally {
 			binput.reset();
 		}
 
-		if (info != null && info.getFormat() == ImageFormat.IMAGE_FORMAT_JPEG) {
-			if (info.getColorType() == ImageInfo.COLOR_TYPE_CMYK) {
+		if (info != null && info.getFormat() == ImageFormats.JPEG) {
+			if (info.getColorType() == ImageInfo.ColorType.CMYK) {
 				final ImageReader reader = getMonkeyReader();
 
 				if (reader == null) {

--- a/core/core-image/src/main/java/org/openimaj/image/ImageUtilities.java
+++ b/core/core-image/src/main/java/org/openimaj/image/ImageUtilities.java
@@ -52,11 +52,11 @@ import java.util.StringTokenizer;
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageOutputStream;
 
+import org.apache.commons.imaging.ImageFormats;
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.sanselan.ImageFormat;
-import org.apache.sanselan.Sanselan;
-import org.apache.sanselan.common.byteSources.ByteSource;
-import org.apache.sanselan.common.byteSources.ByteSourceInputStream;
+import org.apache.commons.imaging.Imaging;
+import org.apache.commons.imaging.common.bytesource.ByteSource;
+import org.apache.commons.imaging.common.bytesource.ByteSourceInputStream;
 import org.openimaj.image.colour.ColourSpace;
 import org.openimaj.io.InputStreamObjectReader;
 
@@ -80,7 +80,7 @@ public class ImageUtilities {
 			try {
 				final ByteSource src = new ByteSourceInputStream(stream, name);
 
-				return Sanselan.guessFormat(src) != ImageFormat.IMAGE_FORMAT_UNKNOWN;
+				return Imaging.guessFormat(src) != ImageFormats.UNKNOWN;
 			} catch (final Exception e) {
 				return false;
 			}
@@ -101,14 +101,14 @@ public class ImageUtilities {
 			try {
 				final ByteSource src = new ByteSourceInputStream(stream, name);
 
-				return Sanselan.guessFormat(src) != ImageFormat.IMAGE_FORMAT_UNKNOWN;
+				return Imaging.guessFormat(src) != ImageFormats.UNKNOWN;
 			} catch (final Exception e) {
 				return false;
 			}
 		}
 	};
 
-	/** Lookup table for byte->float conversion */
+	/** Lookup table for byte-&gt;float conversion */
 	public final static float[] BYTE_TO_FLOAT_LUT;
 
 	// Static initialisation

--- a/core/core-image/src/main/java/org/openimaj/image/dataset/BingImageDataset.java
+++ b/core/core-image/src/main/java/org/openimaj/image/dataset/BingImageDataset.java
@@ -503,7 +503,7 @@ public class BingImageDataset<IMAGE extends Image<?, IMAGE>> extends ReadableLis
 			//if the URL is malformed, something went wrong with programming
 			throw new RuntimeException(e);
 		} catch (final IOException e) {
-			if (e.getCause() instanceof org.apache.sanselan.ImageReadException) {
+			if (e.getCause() instanceof org.apache.commons.imaging.ImageReadException) {
 				// image urls that redirect to html pages will have this error (eg tinypic.com)
 				System.out.println("The following URL didn't redirect to an image: " + imageURL);
 			} else {

--- a/core/core-image/src/main/java/org/openimaj/image/renderer/ImageRenderer.java
+++ b/core/core-image/src/main/java/org/openimaj/image/renderer/ImageRenderer.java
@@ -842,7 +842,7 @@ public abstract class ImageRenderer<Q, I extends Image<Q, I>> {
 	/**
 	 * Sanitize the colour given to fit this image's pixel type.
 	 *
-	 * @param size
+	 * @param colour
 	 *            The colour to sanitize
 	 * @return The array
 	 */

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
 							</div>
 							]]></bottom>
 							<linksource>true</linksource>
-							<additionalparam>-Xdoclint:none</additionalparam>
+							<additionalparam>-Xdoclint:none --allow-script-in-comments</additionalparam>
 						</configuration>
 						<executions>
 							<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
 							</div>
 							]]></bottom>
 							<linksource>true</linksource>
-							<additionalparam>-Xdoclint:none --allow-script-in-comments</additionalparam>
+							<additionalparam>-Xdoclint:none</additionalparam>
 						</configuration>
 						<executions>
 							<execution>


### PR DESCRIPTION
https://github.com/openimaj/openimaj/issues/312

Upgrading legacy Sanselan to commons-image, which fixes a couple of CVE vulnerabilities.