### PR TITLE
Could  org.openimaj.tools:SequenceFileMerger:1.4-SNAPSHOT drop off redundant dependencies to loose weight? 

### DIFF
--- a/hadoop/tools/SequenceFileMerger/pom.xml
+++ b/hadoop/tools/SequenceFileMerger/pom.xml
@@ -15,12 +15,79 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+	<groupId>org.apache.hadoop</groupId>
+	<artifactId>hadoop-hdfs</artifactId>
+	<version>2.6.0-cdh5.13.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+	<artifactId>hadoop-core</artifactId>
+	<version>2.6.0-mr1-cdh5.13.3</version>
+      </dependency>
+      <dependency>
+	<groupId>asm</groupId>
+	<artifactId>asm</artifactId>
+	<version>3.1</version>
+      </dependency>
+      <dependency>
+	<groupId>org.codehaus.jettison</groupId>
+	<artifactId>jettison</artifactId>
+	<version>1.1</version>
+      </dependency>
+      <dependency>
+	<groupId>org.codehaus.jackson</groupId>
+	<artifactId>jackson-xc</artifactId>
+	<version>1.8.3</version>
+    </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.openimaj</groupId>
       <artifactId>core-hadoop</artifactId>
       <version>1.4-SNAPSHOT</version>
       <scope>compile</scope>
+      <exclusions>
+	<exclusion>
+	    <groupId>com.sun.xml.bind</groupId>
+	    <artifactId>jaxb-impl</artifactId>
+	</exclusion>
+	<exclusion>
+	    <groupId>javax.servlet</groupId>
+	    <artifactId>servlet-api</artifactId>
+	</exclusion>
+	<exclusion>
+	    <groupId>org.semanticdesktop.aperture</groupId>
+	    <artifactId>aperture-mime-identifier-magic</artifactId>
+	</exclusion>
+	<exclusion>
+	    <groupId>com.sun.jersey</groupId>
+	    <artifactId>jersey-core</artifactId>
+	</exclusion>
+	<exclusion>
+	    <groupId>uk.com.robust-it</groupId>
+	    <artifactId>cloning</artifactId>
+	</exclusion>
+	<exclusion>
+	    <groupId>org.codehaus.jackson</groupId>
+	    <artifactId>jackson-jaxrs</artifactId>
+	</exclusion>
+	<exclusion>
+	    <groupId>xml-apis</groupId>
+	    <artifactId>xml-apis</artifactId>
+	</exclusion>
+	<exclusion>
+	    <groupId>com.sun.jersey</groupId>
+	    <artifactId>jersey-server</artifactId>
+	</exclusion>
+	<exclusion>
+	    <groupId>com.sun.jersey</groupId>
+	    <artifactId>jersey-json</artifactId>
+	</exclusion>
+    </exclusions>
     </dependency>
     <dependency>
       <groupId>org.openimaj.hadoop.tools</groupId>


### PR DESCRIPTION
@jonhare Hi, I am a user of project **_org.openimaj.tools:SequenceFileMerger:1.4-SNAPSHOT_**. I found that its pom file introduced **_113_** dependencies. However, among them, **_15_** libraries (**_13%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.openimaj.tools:SequenceFileMerger:1.4-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile 
javax.servlet:servlet-api:jar:2.5:compile
org.semanticdesktop.aperture:aperture-mime-identifier-magic:jar:1.4.0:compile
com.sun.jersey:jersey-core:jar:1.9:compile
uk.com.robust-it:cloning:jar:1.9.10:compile
org.codehaus.jackson:jackson-jaxrs:jar:1.8.3:compile
xml-apis:xml-apis:jar:1.3.04:compile
com.sun.jersey:jersey-json:jar:1.9:compile
com.sun.jersey:jersey-server:jar:1.9:compile
javax.activation:activation:jar:1.1:compile
asm:asm:jar:3.1:compile
javax.xml.stream:stax-api:jar:1.0-2:compile    
org.codehaus.jackson:jackson-xc:jar:1.8.3:compile
javax.xml.bind:jaxb-api:jar:2.2.2:compile   
org.codehaus.jettison:jettison:jar:1.1:compile
</code></pre>
## Outdated dependencies
javax.xml.stream:stax-api:1.0-2 (**_5780_** days without maintenance)
javax.activation:activation:1.1 (**_6296_** days without maintenance)
xml-apis:xml-apis:1.3.04 (**_6063_** days without maintenance)
asm:asm:3.1 (**_5669_** days without maintenance)
com.sun.jersey:jersey-server:1.9 (**_4348_** days without maintenance)
org.codehaus.jackson:jackson-jaxrs:1.8.3 (**_4403_** days without maintenance)
uk.com.robust-it:cloning:1.9.10 (**_1935_** days without maintenance)